### PR TITLE
:sparkles: 게시글 CR기능

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorTheme": "Default Light Modern"
+}

--- a/articles.html
+++ b/articles.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>게시글</title>
+    <script src="articles.js"></script>
+</head>
+
+<body>
+    <div id="article_list"></div>
+</body>
+
+</html>

--- a/articles.js
+++ b/articles.js
@@ -1,0 +1,86 @@
+window.onload = async () => {
+    const articleListDiv = document.getElementById("article_list");
+
+    try {
+        // 게시글 목록을 가져오는 API 요청
+        const response = await fetch('http://127.0.0.1:8000/articles/');
+        const articles = await response.json();
+        const proxy = "http://127.0.0.1:8000"   // 이미지를 가져오기 위한 백엔드 포트 주소할당
+
+        console.log(articles)
+
+        // 가져온 게시글을 표시
+        articles.forEach((article) => {
+            const articleDiv = document.createElement("div");
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(article.content, "text/html")
+
+            doc.querySelectorAll('img').forEach(img => {
+                let imgSrc = img.getAttribute('src');
+                if (imgSrc.startsWith('/')) {
+                    img.setAttribute('src', proxy + imgSrc);
+                }
+            });
+
+            const bodyContent = doc.body.innerHTML
+            const article_update_at = new Date(article.updated_at).toLocaleString();
+            const image_url = proxy + article.image
+
+
+            articleDiv.innerHTML = `
+                <h3>${article.title}</h3>
+                <h3>수정시간: ${article_update_at}</h3>
+                <h3>작성자: ${article.user}</h3> 
+                <img src=${image_url} alt="썸네일" width="50" height="50">
+                ${bodyContent}
+                <h3>댓글:${article.comments_count}개</h3>
+                <button class="like-button" article_id=${article.pk}>♡ ${article.likes_count}</button>
+            `;
+
+            articleListDiv.appendChild(articleDiv);
+            articleDiv.style.backgroundColor = "lightgray";
+        });
+    } catch (error) {
+        console.error('게시글을 가져오는 중 오류가 발생했습니다:', error);
+    }
+    // 좋아요 함수
+    async function likeArticle(article_id) {
+        try {
+            const like_response = await fetch(`http://127.0.0.1:8000/articles/${article_id}/like/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer <tokken>'
+                },
+            });
+
+            if (like_response.ok) {
+                const result = await like_response.text();
+                console.log(result); // 처리 결과를 출력하거나 필요에 따라 처리할 수 있습니다.
+
+                // 좋아요 버튼의 텍스트 업데이트
+                const likeButton = document.querySelector(`.like-button[article_id="${article_id}"]`);
+                const likeCount = parseInt(likeButton.textContent.split(' ')[1]);
+                if (result === 'like') {
+                    likeButton.textContent = `♡ ${likeCount + 1}`;
+                } else if (result === 'unlike') {
+                    likeButton.textContent = `♡ ${likeCount - 1}`;
+                }
+            } else {
+                console.error('좋아요 요청이 실패하였습니다.');
+            }
+        } catch (error) {
+            console.error('좋아요 요청 중 오류가 발생하였습니다:', error);
+        }
+    }
+    // 이벤트 리스너 추가
+    const likeButtons = document.querySelectorAll('.like-button');
+    likeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const articleId = button.getAttribute('article_id');
+            likeArticle(articleId);
+        });
+    });
+    // 이하 생략
+
+};

--- a/articles_create.html
+++ b/articles_create.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>게시글 작성</title>
+    <script src="https://cdn.ckeditor.com/ckeditor5/29.0.0/classic/ckeditor.js"></script>
+</head>
+
+<body>
+    <h1>게시글 작성</h1>
+
+    <form id="articleForm">
+        <div>
+            <label for="title">제목:</label>
+            <input type="text" id="title" name="title" required>
+        </div>
+        <div>
+            <label for="image">이미지:</label>
+            <input type="file" id="image" name="image">
+        </div>
+        <div>
+            <label for="content">내용:</label>
+            <div id="editor">
+
+            </div>
+        </div>
+        <button id="save-button">작성</button>
+    </form>
+
+    <script>
+        let editorInstance;
+
+        ClassicEditor
+            .create(document.querySelector('#editor'))
+            .then(editor => {
+                console.log(editor)
+                editorInstance = editor;
+
+            })
+            .catch(error => {
+                console.error(error);
+            });
+
+        document.getElementById('save-button').addEventListener('click', function () {
+            const editorData = editorInstance.getData();
+            console.log(editorData)
+            createArticle(editorData)
+        })
+
+        async function createArticle(editorData) {
+            // 게시글 작성 폼에서 입력된 데이터 수집
+            const title = document.getElementById('title').value;
+            // const content = document.getElementById('content').innerHTML;
+            const content = editorData;
+            const image = document.getElementById('image').files[0];
+
+
+            // FormData 객체 생성 및 데이터 추가
+            const formData = new FormData();
+            formData.append('title', title);
+            formData.append('content', content);
+            formData.append('image', image);
+
+            console.log(formData);
+
+            try {
+                // POST 요청 보내기
+                const response = await fetch('http://127.0.0.1:8000/articles/', {
+                    method: 'POST',
+                    body: formData,
+                    headers: {
+                        'Authorization': 'Bearer <tokken>'
+                    },
+                });
+
+                // 응답 처리
+                if (response.ok) {
+                    const article = await response.json();
+                    console.log('게시글이 작성되었습니다:', article);
+                    // 게시글 작성 성공 시, 필요한 처리 작업 수행
+                } else {
+                    console.error('게시글 작성에 실패했습니다:', response.statusText);
+                    // 게시글 작성 실패 시, 필요한 처리 작업 수행
+                }
+            } catch (error) {
+                console.error('게시글 작성 중 오류가 발생했습니다:', error);
+                // 오류 처리 작업 수행
+            }
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
게시글 CR기능을 작성했습니다.

Read는 구현완료했고
Create의 경우 글자관련(굵은글씨 등)은 가능하나 사진, 동영상 등은 본문에 작성하게 만들지 못했습니다.

작성한 코드들을 보면 headers에 Auth가 있습니다. 토큰이라 써진 곳에 토큰을 지우고 토큰값을 넣으면 됩니다.

게시글 페이지는 좋아요와 댓글의 수도 확인할 수 있게 만들었고 좋아요의 경우 눌러서 좋아요 혹은 좋아요 취소가 되지만 새로고침을 해야지만 바뀐 결과를 확인할 수 있습니다.

프론트 디자인을 위해 아직 미완성이지만 먼저 지금까지 한 기능들을 보냅니다.